### PR TITLE
Enable C++11 by default to fix clang build error

### DIFF
--- a/tools/conv/CMakeLists.txt
+++ b/tools/conv/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.10.0)
+set (CMAKE_CXX_STANDARD 11)
 project(converter)
 
 # DMG converter


### PR DESCRIPTION
`clang` does not enable C++11 by default, but C++11 features are used in gfxconv.cpp. I modified CMakeLists.txt to enable C++11.